### PR TITLE
delete CNAME to prevent redirect

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-jacquesfuentes.com


### PR DESCRIPTION
since the domain isn't serving the github site anymore, and I want to setup the documentation for php-activerecord at https://jpfuentes2.github.io/php-activerecord, this needs to go. otherwise it keeps redirecting to http://www.jacquesfuentes.com/php-activerecord